### PR TITLE
Removed forcing pod settings to 3.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,13 +27,3 @@ end
 target "iOS-Starter-Kit" do
   important_pods
 end
-
-
-# iOS
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['SWIFT_VERSION'] = '3.0'
-    end
-  end
-end


### PR DESCRIPTION
No longer required with current versions of CocoaPods.